### PR TITLE
Report adapter_name as mysql2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+- report `adapter_name` as `mysql2` for compatibility with gems that check it (e.g. [mceachen/with_advisory_lock](https://github.com/mceachen/with_advisory_lock))
+
 ## 0.1.1
 
 - now compatible with versions 0.5.0 and later of [zdennis/activerecord-import](https://github.com/zdennis/activerecord-import)

--- a/lib/active_record/connection_adapters/mysql_pt_osc_adapter.rb
+++ b/lib/active_record/connection_adapters/mysql_pt_osc_adapter.rb
@@ -20,6 +20,10 @@ module ActiveRecord
     class MysqlPtOscAdapter < Mysql2Adapter
       ADAPTER_NAME = 'mysql-pt-osc'
 
+      def adapter_name
+        'mysql2' # For compatibility with code that check adapter name
+      end
+
       # Renames a table.
       #
       # Example:

--- a/lib/pt-osc/version.rb
+++ b/lib/pt-osc/version.rb
@@ -1,5 +1,5 @@
 module Pt
   module Osc
-    VERSION = '0.1.1'
+    VERSION = '0.1.2'
   end
 end


### PR DESCRIPTION
For better compatibility with gems that ask for it.
- bump version to 0.1.2
- update changelog
