### PR TITLE
Allow "dangerous" ALTER statements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ branches:
     - master
 language: ruby
 rvm:
-  - 1.9.2
   - 1.9.3
   - 2.0.0
   - 2.1.2

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ This gem is not considered production ready. There will be bugs.
 
 Support for other versions of Ruby or ActiveRecord is unknown and not guaranteed.
 
+`pt-osc` requires the use of `pt-online-schema-change` 2.0 or later. Some options may not work with all versions.
+
 `pt-osc` is compatible with versions 0.5.0 and later of [zdennis/activerecord-import](https://github.com/zdennis/activerecord-import). It will not work with earlier versions.
 
 #License and Copyright

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ environment:
 
 Additional/modified options for the `percona` hash include:
   - `defaults-file`: Can be specified as an absolute path (with leading `/`) or relative (without). Relative paths will be treated as relative to your project's working directory.
+  - `check-alter`: When set to `false`, `ALTER` commands will not be checked when executing (same as [`--no-check-alter`](http://www.percona.com/doc/percona-toolkit/2.1/pt-online-schema-change.html#cmdoption-pt-online-schema-change--%5Bno%5Dcheck-alter))
   - `run_mode`: Specify `'execute'` to actually run `pt-online-schema-change` when the migration runs. Specify `'print'` to output the commands to run to STDOUT instead. Default is `'print'`.
   - `log`: Specify the file used for logging activity. Can be a relative or absolute path.
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ This gem is not considered production ready. There will be bugs.
 
 `pt-osc` is tested against:
 - ActiveRecord 3.2 branch
-  - Ruby 1.9.2
   - Ruby 1.9.3
   - Ruby 2.0.0
   - Ruby 2.1.2

--- a/lib/active_record/pt_osc_migration.rb
+++ b/lib/active_record/pt_osc_migration.rb
@@ -174,6 +174,7 @@ module ActiveRecord
     private
     def command_flags(options)
       options.map do |key, value|
+        next if key == 'execute'
         flag_options = self.class.percona_flags[key]
 
         # Satisfy version requirements
@@ -197,7 +198,7 @@ module ActiveRecord
     end
 
     def run_mode_flag(options)
-      options.delete(:execute) ? ' --execute' : ' --dry-run'
+      options[:execute] ? ' --execute' : ' --dry-run'
     end
 
     def self.get_tool_version
@@ -209,6 +210,10 @@ module ActiveRecord
       return path if path[0] == '/'
       # If path is not already absolute, treat it as relative to the app root
       File.expand_path(path, Dir.getwd)
+    end
+
+    def execute_only(flag, options = {})
+      options[:all_options][:execute] ? flag : self.class.percona_flags[options[:flag_name]][:default]
     end
   end
 end

--- a/lib/active_record/pt_osc_migration.rb
+++ b/lib/active_record/pt_osc_migration.rb
@@ -182,7 +182,9 @@ module ActiveRecord
         end
 
         # Mutate the value if needed
-        value = send(self.class.percona_flags[key][:mutator], value) if self.class.percona_flags[key].try(:key?, :mutator)
+        if flag_options.try(:key?, :mutator)
+          value = send(flag_options[:mutator], value, all_options: options, flag_name: key)
+        end
 
         # Handle boolean flags
         if flag_options.try(:[], :boolean)
@@ -203,7 +205,7 @@ module ActiveRecord
     end
 
     # Flag mutators
-    def make_path_absolute(path)
+    def make_path_absolute(path, _ = {})
       return path if path[0] == '/'
       # If path is not already absolute, treat it as relative to the app root
       File.expand_path(path, Dir.getwd)

--- a/lib/active_record/pt_osc_migration.rb
+++ b/lib/active_record/pt_osc_migration.rb
@@ -14,6 +14,12 @@ module ActiveRecord
       'execute' => {
         default: false,
       },
+      'check-alter' => {
+        boolean: true,
+        default: true,
+        mutator: :execute_only,
+        version: '>= 2.1',
+      }
     }.freeze
 
     def self.percona_flags

--- a/lib/active_record/pt_osc_migration.rb
+++ b/lib/active_record/pt_osc_migration.rb
@@ -141,7 +141,7 @@ module ActiveRecord
 
       # Set defaults
       self.class.percona_flags.each do |flag, flag_config|
-        options[flag] ||= flag_config[:default] if flag_config.key?(:default)
+        options[flag] = flag_config[:default] if flag_config.key?(:default) && !options.key?(flag)
       end
 
       # Determine run mode
@@ -157,6 +157,12 @@ module ActiveRecord
 
         # Mutate the value if needed
         value = send(self.class.percona_flags[key][:mutator], value) if self.class.percona_flags[key].try(:key?, :mutator)
+
+        # Handle boolean flags
+        if flag_options.try(:[], :boolean)
+          key = "no-#{key}" unless value
+          value = nil
+        end
 
         command += " --#{key} #{value}"
       end

--- a/lib/pt-osc/version.rb
+++ b/lib/pt-osc/version.rb
@@ -1,5 +1,5 @@
 module Pt
   module Osc
-    VERSION = '0.1.3'
+    VERSION = '0.2.0'
   end
 end

--- a/pt-osc.gemspec
+++ b/pt-osc.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'shoulda'
   spec.add_development_dependency 'faker'
-  spec.add_development_dependency 'mocha'
+  spec.add_development_dependency 'mocha', '>= 0.9.0'
 
   # For testing using dummy Rails app
   spec.add_development_dependency 'rails', '~> 3.2'

--- a/test/config/database.yml
+++ b/test/config/database.yml
@@ -24,3 +24,8 @@ test_execute_string:
   <<: *test
   percona:
     run_mode: 'execute'
+
+test_no_check_alter:
+  <<: *test
+  percona:
+    check-alter: false

--- a/test/functional/pt_osc_migration_functional_test.rb
+++ b/test/functional/pt_osc_migration_functional_test.rb
@@ -3,11 +3,9 @@ require 'test_helper'
 class PtOscMigrationFunctionalTest < ActiveRecord::TestCase
   class TestMigration < ActiveRecord::PtOscMigration; end
 
-  context 'a migration connected to a pt-osc database' do
+  context 'a migration' do
     setup do
-      ActiveRecord::Base.establish_connection(test_spec)
       @migration = TestMigration.new
-      @migration.instance_variable_set(:@connection, ActiveRecord::Base.connection)
       ActiveRecord::PtOscMigration.stubs(:tool_version).returns(Gem::Version.new('100'))
     end
 
@@ -15,29 +13,35 @@ class PtOscMigrationFunctionalTest < ActiveRecord::TestCase
       ActiveRecord::PtOscMigration.unstub(:tool_version)
     end
 
-    context 'on an existing table with an existing column' do
+    context 'connected to a pt-osc database' do
       setup do
-        @table_name = Faker::Lorem.word
-        @column_name = Faker::Lorem.word
-        @index_name = Faker::Lorem.words.join('_')
-        @index_name_2 = "#{@index_name}_2"
+        ActiveRecord::Base.establish_connection(test_spec)
+        @migration.instance_variable_set(:@connection, ActiveRecord::Base.connection)
+      end
 
-        ActiveRecord::Base.connection.execute "DROP TABLE IF EXISTS `#{@table_name}`;"
-        ActiveRecord::Base.connection.execute <<-SQL
+      context 'on an existing table with an existing column' do
+        setup do
+          @table_name = Faker::Lorem.word
+          @column_name = Faker::Lorem.word
+          @index_name = Faker::Lorem.words.join('_')
+          @index_name_2 = "#{@index_name}_2"
+
+          ActiveRecord::Base.connection.execute "DROP TABLE IF EXISTS `#{@table_name}`;"
+          ActiveRecord::Base.connection.execute <<-SQL
           CREATE TABLE `#{@table_name}` (
             `#{@column_name}` varchar(255) DEFAULT NULL,
             KEY `#{@index_name}` (`#{@column_name}`)
           );
-        SQL
-      end
+          SQL
+        end
 
-      teardown do
-        ActiveRecord::Base.connection.execute "DROP TABLE IF EXISTS `#{@table_name}`;"
-      end
+        teardown do
+          ActiveRecord::Base.connection.execute "DROP TABLE IF EXISTS `#{@table_name}`;"
+        end
 
-      context 'a migration with only ALTER statements' do
-        setup do
-          TestMigration.class_eval <<-EVAL
+        context 'a migration with only ALTER statements' do
+          setup do
+            TestMigration.class_eval <<-EVAL
             def change
               rename_table  :#{@table_name}, :#{Faker::Lorem.word}
               add_column    :#{@table_name}, :#{Faker::Lorem.word}, :integer
@@ -47,57 +51,78 @@ class PtOscMigrationFunctionalTest < ActiveRecord::TestCase
               add_index     :#{@table_name}, :#{@column_name}, name: :#{@index_name_2}
               remove_index  :#{@table_name}, name: :#{@index_name}
             end
-          EVAL
-        end
-
-        teardown do
-          TestMigration.send(:remove_method, :change)
-        end
-
-        context 'ignoring schema lookups' do
-          setup do
-            # Kind of a hacky way to do this
-            ignored_sql = ActiveRecord::SQLCounter.ignored_sql + [
-              /^SHOW FULL FIELDS FROM/,
-              /^SHOW COLUMNS FROM/,
-              /^SHOW KEYS FROM/,
-            ]
-            ActiveRecord::SQLCounter.any_instance.stubs(:ignore).returns(ignored_sql)
+            EVAL
           end
 
           teardown do
-            ActiveRecord::SQLCounter.any_instance.unstub(:ignore)
+            TestMigration.send(:remove_method, :change)
           end
 
-          context 'with suppressed output' do
+          context 'ignoring schema lookups' do
             setup do
-              @migration.stubs(:write)
-              @migration.stubs(:announce)
+              # Kind of a hacky way to do this
+              ignored_sql = ActiveRecord::SQLCounter.ignored_sql + [
+                /^SHOW FULL FIELDS FROM/,
+                /^SHOW COLUMNS FROM/,
+                /^SHOW KEYS FROM/,
+              ]
+              ActiveRecord::SQLCounter.any_instance.stubs(:ignore).returns(ignored_sql)
             end
 
             teardown do
-              @migration.unstub(:write, :announce)
+              ActiveRecord::SQLCounter.any_instance.unstub(:ignore)
             end
 
-            should 'not execute any queries immediately' do
-              assert_no_queries { @migration.change }
-            end
-
-            context 'with a working pt-online-schema-change' do
+            context 'with suppressed output' do
               setup do
-                Kernel.expects(:system).with(regexp_matches(/^pt-online-schema-change/)).twice.returns(true)
+                @migration.stubs(:write)
+                @migration.stubs(:announce)
               end
 
               teardown do
-                Kernel.unstub(:system)
+                @migration.unstub(:write, :announce)
               end
 
-              should 'not directly execute any queries when migrating' do
-                assert_no_queries { @migration.migrate(:up) }
+              should 'not execute any queries immediately' do
+                assert_no_queries { @migration.change }
+              end
+
+              context 'with a working pt-online-schema-change' do
+                setup do
+                  Kernel.expects(:system).with(regexp_matches(/^pt-online-schema-change/)).twice.returns(true)
+                end
+
+                teardown do
+                  Kernel.unstub(:system)
+                end
+
+                should 'not directly execute any queries when migrating' do
+                  assert_no_queries { @migration.migrate(:up) }
+                end
               end
             end
           end
         end
+      end
+    end
+
+    context 'connected without checking alter statements' do
+      setup do
+        @old_connection = @migration.instance_variable_get(:@connection)
+        ActiveRecord::Base.establish_connection(test_spec('test_no_check_alter'))
+        @migration.instance_variable_set(:@connection, ActiveRecord::Base.connection)
+      end
+
+      should 'check ALTER when dry-running sql' do
+        command = @migration.send(:percona_command, nil, nil, nil, execute: false)
+        assert command.include?('--check-alter'), "Command '#{command}' did not include ALTER check."
+        assert_equal false, command.include?('--no-check-alter'), "Command '#{command}' should not disable ALTER check."
+      end
+
+      should 'not check ALTER when executing sql' do
+        command = @migration.send(:percona_command, nil, nil, nil, execute: true)
+        assert command.include?('--no-check-alter'), "Command '#{command}' should not include ALTER check."
+        assert_equal false, command.include?('--check-alter'), "Command '#{command}' should disable ALTER check."
       end
     end
   end

--- a/test/functional/pt_osc_migration_functional_test.rb
+++ b/test/functional/pt_osc_migration_functional_test.rb
@@ -8,6 +8,11 @@ class PtOscMigrationFunctionalTest < ActiveRecord::TestCase
       ActiveRecord::Base.establish_connection(test_spec)
       @migration = TestMigration.new
       @migration.instance_variable_set(:@connection, ActiveRecord::Base.connection)
+      ActiveRecord::PtOscMigration.stubs(:tool_version).returns(Gem::Version.new('100'))
+    end
+
+    teardown do
+      ActiveRecord::PtOscMigration.unstub(:tool_version)
     end
 
     context 'on an existing table with an existing column' do

--- a/test/unit/pt_osc_migration_unit_test.rb
+++ b/test/unit/pt_osc_migration_unit_test.rb
@@ -271,6 +271,24 @@ class PtOscMigrationUnitTest < Test::Unit::TestCase
       end
     end
 
+    context '#execute_only' do
+      should 'return the default flag value during a dry run' do
+        ActiveRecord::PtOscMigration.stubs(:percona_flags).returns('foo' => { default: 'bar' })
+        assert_equal 'bar', @migration.send(:execute_only, 'baz', all_options: { execute: false }, flag_name: 'foo')
+        ActiveRecord::PtOscMigration.unstub(:percona_flags)
+      end
+
+      should 'return nil during a dry run if there is no default value' do
+        ActiveRecord::PtOscMigration.stubs(:percona_flags).returns('foo' => {})
+        assert_nil @migration.send(:execute_only, 'baz', all_options: { execute: false }, flag_name: 'foo')
+        ActiveRecord::PtOscMigration.unstub(:percona_flags)
+      end
+
+      should 'pass the flag through when executing' do
+        assert_equal 'baz', @migration.send(:execute_only, 'baz', all_options: { execute: true }, flag_name: 'foo')
+      end
+    end
+
     context '#execute_pt_osc' do
       context 'with a pt-osc connection' do
         setup do

--- a/test/unit/pt_osc_migration_unit_test.rb
+++ b/test/unit/pt_osc_migration_unit_test.rb
@@ -154,7 +154,7 @@ class PtOscMigrationUnitTest < Test::Unit::TestCase
           end
 
           should 'call #make_path_absolute' do
-            @migration.expects(:make_path_absolute).with(@path)
+            @migration.expects(:make_path_absolute).with(@path, anything)
             @migration.send(:percona_command, '', '', '', @options)
           end
         end

--- a/test/unit/pt_osc_migration_unit_test.rb
+++ b/test/unit/pt_osc_migration_unit_test.rb
@@ -101,6 +101,27 @@ class PtOscMigrationUnitTest < Test::Unit::TestCase
           end
         end
 
+        context 'with boolean flags' do
+          setup do
+            flags = ActiveRecord::PtOscMigration.percona_flags.merge({ 'boolean-flag' => { boolean: true } })
+            ActiveRecord::PtOscMigration.stubs(:percona_flags).returns(flags)
+          end
+
+          teardown do
+            ActiveRecord::PtOscMigration.unstub(:percona_flags)
+          end
+
+          should 'include just the flag (no value) when true' do
+            command = @migration.send(:percona_command, '', '', '', 'boolean-flag' => true)
+            assert command =~ /\-\-boolean\-flag\s*$/, "Boolean flag was malformed in command '#{command}'."
+          end
+
+          should 'include a "no" version of the flag when false' do
+            command = @migration.send(:percona_command, '', '', '', 'boolean-flag' => false)
+            assert command =~ /\-\-no\-boolean\-flag\s*$/, "Boolean flag was malformed in command '#{command}'."
+          end
+        end
+
         should 'perform a dry run if execute not specified' do
           command = @migration.send(:percona_command, '', '', '')
           assert command.include?('--dry-run')

--- a/test/unit/pt_osc_migration_unit_test.rb
+++ b/test/unit/pt_osc_migration_unit_test.rb
@@ -53,7 +53,7 @@ class PtOscMigrationUnitTest < Test::Unit::TestCase
 
           should 'set missing flags to default values' do
             flags_with_defaults = ActiveRecord::PtOscMigration.percona_flags.select do |flag, config|
-              config.key?(:default) && flag != 'execute'
+              config.key?(:default) && flag != 'execute' && !config[:boolean]
             end
 
             command = @migration.send(:percona_command, '', '', '')
@@ -123,12 +123,16 @@ class PtOscMigrationUnitTest < Test::Unit::TestCase
 
           should 'include just the flag (no value) when true' do
             command = @migration.send(:percona_command, '', '', '', 'boolean-flag' => true)
-            assert command =~ /\-\-boolean\-flag\s*$/, "Boolean flag was malformed in command '#{command}'."
+            matches_eof = command =~ /\-\-boolean\-flag\s*$/
+            matches_middle = command =~ /\-\-boolean\-flag\s*\-\-/
+            assert matches_eof || matches_middle, "Boolean flag was malformed in command '#{command}'."
           end
 
           should 'include a "no" version of the flag when false' do
             command = @migration.send(:percona_command, '', '', '', 'boolean-flag' => false)
-            assert command =~ /\-\-no\-boolean\-flag\s*$/, "Boolean flag was malformed in command '#{command}'."
+            matches_eof = command =~ /\-\-no\-boolean\-flag\s*$/
+            matches_middle = command =~ /\-\-no\-boolean\-flag\s*\-\-/
+            assert matches_eof || matches_middle, "Boolean flag was malformed in command '#{command}'."
           end
         end
 


### PR DESCRIPTION
This PR enables the use of the `--check-alter`/`--no-check-alter` to bypass `pt-online-schema-change`'s [`ALTER` statement checking behavior](http://www.percona.com/doc/percona-toolkit/2.1/pt-online-schema-change.html#cmdoption-pt-online-schema-change--[no]check-alter), enabling migrations using `rename_column`.

It also lays some groundwork for supporting additional flags; primarily, support for boolean flags that follow the same `--[no]-` format and checking required versions of the tool before using a given flag.