### PR TITLE
Double quote --alter statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.1
+
+- properly quote string values in MySQL commands
+- added additional tests
+
 ## 0.2.0
 
 - support for setting the [`--check-alter` flag](http://www.percona.com/doc/percona-toolkit/2.1/pt-online-schema-change.html#cmdoption-pt-online-schema-change--%5Bno%5Dcheck-alter)

--- a/lib/active_record/connection_adapters/mysql_pt_osc_adapter.rb
+++ b/lib/active_record/connection_adapters/mysql_pt_osc_adapter.rb
@@ -108,6 +108,18 @@ module ActiveRecord
         add_command(table_name, "DROP INDEX #{quote_column_name(index_name)}")
       end
 
+      # Convert single quotes to double quotes as conservatively as possible
+      def quote(value, column = nil)
+        quoted = super
+        if value.kind_of?(String) && column && column.type == :binary && column.class.respond_to?(:string_to_binary)
+          quoted[1] = '"' if quoted[0] == 'x' && quoted[1] == "'"
+        else
+          quoted[0] = '"' if quoted[0] == "'"
+        end
+        quoted[-1] = '"' if quoted[-1] == "'"
+        quoted
+      end
+
       def clear_commands
         @osc_commands = {}
       end

--- a/lib/pt-osc/version.rb
+++ b/lib/pt-osc/version.rb
@@ -1,5 +1,5 @@
 module Pt
   module Osc
-    VERSION = '0.2.0'
+    VERSION = '0.2.1'
   end
 end

--- a/test/functional/pt_osc_migration_functional_test.rb
+++ b/test/functional/pt_osc_migration_functional_test.rb
@@ -51,6 +51,7 @@ class PtOscMigrationFunctionalTest < ActiveRecord::TestCase
               rename_table  :#{@table_name}, :#{@new_table_name}
               add_column    :#{@table_name}, :#{@new_column_name}, :integer
               change_column :#{@table_name}, :#{@column_name}, :varchar, default: 'newthing'
+              change_column :#{@table_name}, :#{@column_name}, :varchar, default: :newsymbol
               rename_column :#{@table_name}, :#{@column_name}, :#{@renamed_column_name}
               remove_column :#{@table_name}, :#{@column_name}
               add_index     :#{@table_name}, :#{@column_name}, name: :#{@index_name_2}
@@ -114,6 +115,7 @@ class PtOscMigrationFunctionalTest < ActiveRecord::TestCase
                   RENAME TO `#{@new_table_name}`
                   ADD `#{@new_column_name}` int(11)
                   CHANGE `#{@column_name}` `#{@column_name}` varchar DEFAULT 'newthing'
+                  CHANGE `#{@column_name}` `#{@column_name}` varchar DEFAULT 'newsymbol'
                   CHANGE `#{@column_name}` `#{@renamed_column_name}` varchar(255) DEFAULT NULL
                   DROP COLUMN `#{@column_name}`
                   ADD  INDEX `#{@index_name_2}` (`#{@column_name}`)

--- a/test/functional/pt_osc_migration_functional_test.rb
+++ b/test/functional/pt_osc_migration_functional_test.rb
@@ -44,6 +44,7 @@ class PtOscMigrationFunctionalTest < ActiveRecord::TestCase
             @new_column_name = Faker::Lorem.word
             @new_table_name = Faker::Lorem.word
             @index_name_2 = "#{@index_name}_2"
+            @index_name_3 = "#{@index_name}_3"
 
             TestMigration.class_eval <<-EVAL
             def change
@@ -53,6 +54,7 @@ class PtOscMigrationFunctionalTest < ActiveRecord::TestCase
               rename_column :#{@table_name}, :#{@column_name}, :#{@renamed_column_name}
               remove_column :#{@table_name}, :#{@column_name}
               add_index     :#{@table_name}, :#{@column_name}, name: :#{@index_name_2}
+              add_index     :#{@table_name}, [:#{@new_column_name}, :#{@renamed_column_name}], name: :#{@index_name_3}, unique: true
               remove_index  :#{@table_name}, name: :#{@index_name}
             end
             EVAL
@@ -115,6 +117,7 @@ class PtOscMigrationFunctionalTest < ActiveRecord::TestCase
                   CHANGE `#{@column_name}` `#{@renamed_column_name}` varchar(255) DEFAULT NULL
                   DROP COLUMN `#{@column_name}`
                   ADD  INDEX `#{@index_name_2}` (`#{@column_name}`)
+                  ADD UNIQUE INDEX `#{@index_name_3}` (`#{@new_column_name}`, `#{@renamed_column_name}`)
                   DROP INDEX `#{@index_name}`
                 ALTER
                 expected_alter.strip!.gsub!(/^\s*/, '').gsub!("\n", ',')

--- a/test/functional/pt_osc_migration_functional_test.rb
+++ b/test/functional/pt_osc_migration_functional_test.rb
@@ -24,7 +24,6 @@ class PtOscMigrationFunctionalTest < ActiveRecord::TestCase
           @table_name = Faker::Lorem.word
           @column_name = Faker::Lorem.word
           @index_name = Faker::Lorem.words.join('_')
-          @index_name_2 = "#{@index_name}_2"
 
           ActiveRecord::Base.connection.execute "DROP TABLE IF EXISTS `#{@table_name}`;"
           ActiveRecord::Base.connection.execute <<-SQL
@@ -41,12 +40,17 @@ class PtOscMigrationFunctionalTest < ActiveRecord::TestCase
 
         context 'a migration with only ALTER statements' do
           setup do
+            @renamed_column_name = Faker::Lorem.word
+            @new_column_name = Faker::Lorem.word
+            @new_table_name = Faker::Lorem.word
+            @index_name_2 = "#{@index_name}_2"
+
             TestMigration.class_eval <<-EVAL
             def change
-              rename_table  :#{@table_name}, :#{Faker::Lorem.word}
-              add_column    :#{@table_name}, :#{Faker::Lorem.word}, :integer
+              rename_table  :#{@table_name}, :#{@new_table_name}
+              add_column    :#{@table_name}, :#{@new_column_name}, :integer
               change_column :#{@table_name}, :#{@column_name}, :varchar, default: 'newthing'
-              rename_column :#{@table_name}, :#{@column_name}, :#{Faker::Lorem.word}
+              rename_column :#{@table_name}, :#{@column_name}, :#{@renamed_column_name}
               remove_column :#{@table_name}, :#{@column_name}
               add_index     :#{@table_name}, :#{@column_name}, name: :#{@index_name_2}
               remove_index  :#{@table_name}, name: :#{@index_name}
@@ -58,29 +62,29 @@ class PtOscMigrationFunctionalTest < ActiveRecord::TestCase
             TestMigration.send(:remove_method, :change)
           end
 
-          context 'ignoring schema lookups' do
+          context 'with suppressed output' do
             setup do
-              # Kind of a hacky way to do this
-              ignored_sql = ActiveRecord::SQLCounter.ignored_sql + [
-                /^SHOW FULL FIELDS FROM/,
-                /^SHOW COLUMNS FROM/,
-                /^SHOW KEYS FROM/,
-              ]
-              ActiveRecord::SQLCounter.any_instance.stubs(:ignore).returns(ignored_sql)
+              @migration.stubs(:write)
+              @migration.stubs(:announce)
             end
 
             teardown do
-              ActiveRecord::SQLCounter.any_instance.unstub(:ignore)
+              @migration.unstub(:write, :announce)
             end
 
-            context 'with suppressed output' do
+            context 'ignoring schema lookups' do
               setup do
-                @migration.stubs(:write)
-                @migration.stubs(:announce)
+                # Kind of a hacky way to do this
+                ignored_sql = ActiveRecord::SQLCounter.ignored_sql + [
+                  /^SHOW FULL FIELDS FROM/,
+                  /^SHOW COLUMNS FROM/,
+                  /^SHOW KEYS FROM/,
+                ]
+                ActiveRecord::SQLCounter.any_instance.stubs(:ignore).returns(ignored_sql)
               end
 
               teardown do
-                @migration.unstub(:write, :announce)
+                ActiveRecord::SQLCounter.any_instance.unstub(:ignore)
               end
 
               should 'not execute any queries immediately' do
@@ -99,6 +103,24 @@ class PtOscMigrationFunctionalTest < ActiveRecord::TestCase
                 should 'not directly execute any queries when migrating' do
                   assert_no_queries { @migration.migrate(:up) }
                 end
+              end
+            end
+
+            context 'the resulting command' do
+              should 'have the correct pt-osc ALTER statement' do
+                expected_alter = <<-ALTER
+                  RENAME TO `#{@new_table_name}`
+                  ADD `#{@new_column_name}` int(11)
+                  CHANGE `#{@column_name}` `#{@column_name}` varchar DEFAULT 'newthing'
+                  CHANGE `#{@column_name}` `#{@renamed_column_name}` varchar(255) DEFAULT NULL
+                  DROP COLUMN `#{@column_name}`
+                  ADD  INDEX `#{@index_name_2}` (`#{@column_name}`)
+                  DROP INDEX `#{@index_name}`
+                ALTER
+                expected_alter.strip!.gsub!(/^\s*/, '').gsub!("\n", ',')
+
+                @migration.change
+                assert_equal expected_alter, @migration.connection.get_commands_string(@table_name)
               end
             end
           end

--- a/test/functional/pt_osc_migration_functional_test.rb
+++ b/test/functional/pt_osc_migration_functional_test.rb
@@ -110,12 +110,17 @@ class PtOscMigrationFunctionalTest < ActiveRecord::TestCase
             end
 
             context 'the resulting command' do
+              setup do
+                @migration.change
+                @command_string = @migration.connection.get_commands_string(@table_name)
+              end
+
               should 'have the correct pt-osc ALTER statement' do
                 expected_alter = <<-ALTER
                   RENAME TO `#{@new_table_name}`
                   ADD `#{@new_column_name}` int(11)
-                  CHANGE `#{@column_name}` `#{@column_name}` varchar DEFAULT 'newthing'
-                  CHANGE `#{@column_name}` `#{@column_name}` varchar DEFAULT 'newsymbol'
+                  CHANGE `#{@column_name}` `#{@column_name}` varchar DEFAULT "newthing"
+                  CHANGE `#{@column_name}` `#{@column_name}` varchar DEFAULT "newsymbol"
                   CHANGE `#{@column_name}` `#{@renamed_column_name}` varchar(255) DEFAULT NULL
                   DROP COLUMN `#{@column_name}`
                   ADD  INDEX `#{@index_name_2}` (`#{@column_name}`)
@@ -124,8 +129,12 @@ class PtOscMigrationFunctionalTest < ActiveRecord::TestCase
                 ALTER
                 expected_alter.strip!.gsub!(/^\s*/, '').gsub!("\n", ',')
 
-                @migration.change
-                assert_equal expected_alter, @migration.connection.get_commands_string(@table_name)
+                assert_equal expected_alter, @command_string
+              end
+
+              should 'not nest identical quotes in ALTER statement' do
+                command = @migration.send(:percona_command, @command_string, 'database', @table_name)
+                assert_match /--alter '[^']+' D=database,t=#{@table_name}/, command
               end
             end
           end

--- a/test/unit/pt_osc_migration_unit_test.rb
+++ b/test/unit/pt_osc_migration_unit_test.rb
@@ -6,10 +6,13 @@ class PtOscMigrationUnitTest < Test::Unit::TestCase
       @migration = ActiveRecord::PtOscMigration.new
       @tool_version = states('tool_version').starts_as('100')
       ActiveRecord::PtOscMigration.stubs(:tool_version).returns(Gem::Version.new('100')).when(@tool_version.is('100'))
+      @migration.stubs(:write)
+      @migration.stubs(:announce)
     end
 
     teardown do
       ActiveRecord::PtOscMigration.unstub(:tool_version)
+      @migration.unstub(:write, :announce)
     end
 
     context '#percona_command' do


### PR DESCRIPTION
Values inside the MySQL `ALTER` command will often be single-quoted. Change these to be doubly-quoted strings so they are interpreted correctly within the singly-quoted `--alter` value.

Fixes PagerDuty/pt-osc#12