### PR TITLE
Warn when ALTERing without PtOscMigration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.3
+
+- a warning will be issued if an `ALTER` command is called outside of a PtOscMigration
+
 ## 0.2.2
 
 - fix bugs with string quoting, use shellwords instead

--- a/lib/active_record/connection_adapters/mysql_pt_osc_adapter.rb
+++ b/lib/active_record/connection_adapters/mysql_pt_osc_adapter.rb
@@ -136,7 +136,9 @@ module ActiveRecord
       # Provides the opportunity to handle warnings in a custom way
       # @param [String] message
       def warn(message)
-        super
+        # Rake tasks loaded through Railties had warnings silenced before Rails 4.1
+        # @see https://github.com/rails/rails/pull/11601
+        defined?(Rails) && Rails.version < '4.1' ? enable_warnings { super } : super
       end
 
       def get_commands(table_name = nil)

--- a/lib/active_record/connection_adapters/mysql_pt_osc_adapter.rb
+++ b/lib/active_record/connection_adapters/mysql_pt_osc_adapter.rb
@@ -123,8 +123,20 @@ module ActiveRecord
 
       protected
       def add_command(table_name, command)
+        warn (<<-WARN
+        You are trying to ALTER table "#{table_name}" with the mysql_pt_osc adapter without using an PtOscMigration.
+        Be aware that ALTER commands will only be executed via pt-online-schema-change inside of an ActiveRecord::PtOscMigration.
+        It is likely that although your migration will complete, no schema alterations have been made.
+        WARN
+        ) if caller.any? { |c| c.include? 'active_record/migration.rb' } && caller.none? { |c| c.include? 'active_record/pt_osc_migration.rb' }
         get_commands[table_name] ||= []
         get_commands[table_name] << command
+      end
+
+      # Provides the opportunity to handle warnings in a custom way
+      # @param [String] message
+      def warn(message)
+        super
       end
 
       def get_commands(table_name = nil)

--- a/lib/active_record/pt_osc_migration.rb
+++ b/lib/active_record/pt_osc_migration.rb
@@ -88,6 +88,11 @@ module ActiveRecord
       end
     end
 
+    def method_missing(method, *arguments, &block) # :nodoc:
+      # Putting this here ensures that pt_osc_migration shows up in the caller trace
+      super
+    end
+
     protected
     def execute_pt_osc
       return unless @connection.is_a? ActiveRecord::ConnectionAdapters::MysqlPtOscAdapter

--- a/lib/pt-osc/version.rb
+++ b/lib/pt-osc/version.rb
@@ -1,5 +1,5 @@
 module Pt
   module Osc
-    VERSION = '0.2.2'
+    VERSION = '0.2.3'
   end
 end

--- a/test/functional/mysql_pt_osc_adapter_test.rb
+++ b/test/functional/mysql_pt_osc_adapter_test.rb
@@ -3,6 +3,8 @@ require 'yaml'
 
 class MysqlPtOscAdapterTest < Test::Unit::TestCase
   class TestConnection < ActiveRecord::Base; end
+  class TestArMigration < ActiveRecord::Migration; end
+  class TestPtOscMigration < ActiveRecord::PtOscMigration; end
 
   def test_connection
     # Test that we can open a connection with the pt_osc adapter
@@ -17,5 +19,62 @@ class MysqlPtOscAdapterTest < Test::Unit::TestCase
   def test_activerecord_import_compatibility
     # Test that the adapter can be loaded when using the activerecord-import gem
     assert_nothing_raised { require 'activerecord-import' }
+  end
+
+  context 'connected using stubbed pt-osc adapter' do
+    setup do
+      ActiveRecord::Base.establish_connection(test_spec)
+      ActiveRecord::ConnectionAdapters::MysqlPtOscAdapter.stubs(:execute)
+    end
+
+    teardown do
+      ActiveRecord::ConnectionAdapters::MysqlPtOscAdapter.unstub(:execute)
+    end
+
+    context 'an ActiveRecord::Migration' do
+      setup do
+        @migration = TestArMigration.new
+        @migration.instance_variable_set(:@connection, ActiveRecord::Base.connection)
+        @migration.stubs(:write)
+        @migration.stubs(:announce)
+      end
+
+      teardown do
+        @migration.unstub(:write, :announce)
+      end
+
+      should 'raise a warning when adding columns' do
+        add_column_fixtures.each do |fixture|
+          fixture_command = sprintf(fixture[:command], table: 'a', column: 'b', default: 0, nullable: true)
+          @migration.class.class_eval "def change; #{fixture_command}; end"
+          ActiveRecord::ConnectionAdapters::MysqlPtOscAdapter.any_instance.expects(:warn).once
+          @migration.migrate(:up)
+          @migration.class.send(:remove_method, :change)
+        end
+      end
+    end
+
+    context 'an ActiveRecord::PtOscMigration' do
+      setup do
+        @migration = TestPtOscMigration.new
+        @migration.instance_variable_set(:@connection, ActiveRecord::Base.connection)
+        @migration.stubs(:write)
+        @migration.stubs(:announce)
+      end
+
+      teardown do
+        @migration.unstub(:write, :announce)
+      end
+
+      should 'not raise a warning when adding columns' do
+        add_column_fixtures.each do |fixture|
+          fixture_command = sprintf(fixture[:command], table: 'a', column: 'b', default: 0, nullable: true)
+          @migration.class.class_eval "def change; #{fixture_command}; end"
+          ActiveRecord::ConnectionAdapters::MysqlPtOscAdapter.any_instance.expects(:warn).never
+          @migration.migrate(:up)
+          @migration.class.send(:remove_method, :change)
+        end
+      end
+    end
   end
 end

--- a/test/functional/pt_osc_migration_functional_test.rb
+++ b/test/functional/pt_osc_migration_functional_test.rb
@@ -22,7 +22,7 @@ class PtOscMigrationFunctionalTest < ActiveRecord::TestCase
       context 'on an existing table with an existing column' do
         setup do
           @table_name = Faker::Lorem.word
-          @column_name = Faker::Lorem.word
+          @column_name = 'foobar'
           @index_name = Faker::Lorem.words.join('_')
 
           ActiveRecord::Base.connection.execute "DROP TABLE IF EXISTS `#{@table_name}`;"
@@ -40,8 +40,8 @@ class PtOscMigrationFunctionalTest < ActiveRecord::TestCase
 
         context 'a migration with only ALTER statements' do
           setup do
-            @renamed_column_name = Faker::Lorem.word
-            @new_column_name = Faker::Lorem.word
+            @renamed_column_name = 'foobar'
+            @new_column_name = 'bazqux'
             @new_table_name = Faker::Lorem.word
             @index_name_2 = "#{@index_name}_2"
             @index_name_3 = "#{@index_name}_3"

--- a/test/unit/mysql_pt_osc_adapter_test.rb
+++ b/test/unit/mysql_pt_osc_adapter_test.rb
@@ -7,6 +7,13 @@ class MysqlPtOscAdapterTest < Test::Unit::TestCase
     setup do
       TestConnection.establish_connection(test_spec)
       @adapter = TestConnection.connection
+      # Silence warnings about not using an ActiveRecord::PtOscMigration
+      # @see Kernel#suppress_warnings
+      @original_verbosity, $VERBOSE = $VERBOSE, nil
+    end
+
+    teardown do
+      $VERBOSE = @original_verbosity
     end
 
     context '#rename_table' do

--- a/test/unit/mysql_pt_osc_adapter_test.rb
+++ b/test/unit/mysql_pt_osc_adapter_test.rb
@@ -39,7 +39,7 @@ class MysqlPtOscAdapterTest < Test::Unit::TestCase
 
         should 'add an ADD command to the commands hash' do
           table_name = Faker::Lorem.word
-          column_name = Faker::Lorem.word
+          column_name = 'foobar'
           @adapter.add_column(table_name, column_name, :string, default: 0, null: false)
           assert_equal "ADD `#{column_name}` varchar(255) DEFAULT 0 NOT NULL", @adapter.send(:get_commands, table_name).first
         end
@@ -55,7 +55,7 @@ class MysqlPtOscAdapterTest < Test::Unit::TestCase
         context 'with an existing table and column' do
           setup do
             @table_name = Faker::Lorem.word
-            @column_name = Faker::Lorem.word
+            @column_name = 'foobar'
             @adapter.create_table @table_name, force: true do |t|
               t.string @column_name
             end
@@ -78,14 +78,14 @@ class MysqlPtOscAdapterTest < Test::Unit::TestCase
         context 'with an existing table and column' do
           setup do
             @table_name = Faker::Lorem.word
-            @column_name = Faker::Lorem.word
+            @column_name = 'foobar'
             @adapter.create_table @table_name, force: true do |t|
               t.string @column_name, default: nil
             end
           end
 
           should 'add a CHANGE command to the commands hash' do
-            new_column_name = Faker::Lorem.word
+            new_column_name = 'foobar'
             @adapter.rename_column(@table_name, @column_name, new_column_name)
             assert_equal "CHANGE `#{@column_name}` `#{new_column_name}` varchar(255) DEFAULT NULL", @adapter.send(:get_commands, @table_name).first
           end
@@ -101,14 +101,14 @@ class MysqlPtOscAdapterTest < Test::Unit::TestCase
 
         should 'add a DROP COLUMN command to the commands hash' do
           table_name = Faker::Lorem.word
-          column_name = Faker::Lorem.word
+          column_name = 'foobar'
           @adapter.remove_column(table_name, column_name)
           assert_equal "DROP COLUMN `#{column_name}`", @adapter.send(:get_commands, table_name).first
         end
 
         should 'add multiple DROP COLUMN commands to the commands hash' do
           table_name = Faker::Lorem.word
-          column_names = 3.times.map { Faker::Lorem.word }
+          column_names = %w(foo bar baz)
           @adapter.remove_column(table_name, *column_names)
           commands = @adapter.send(:get_commands, table_name)
           column_names.each_with_index do |column_name, index|
@@ -127,7 +127,7 @@ class MysqlPtOscAdapterTest < Test::Unit::TestCase
         context 'with an existing table and columns' do
           setup do
             @table_name = Faker::Lorem.word
-            @column_names = Faker::Lorem.words
+            @column_names = %w(foo bar baz)
             @adapter.create_table @table_name, force: true do |t|
               @column_names.each do |column_name|
                 t.string(column_name, default: nil)
@@ -164,7 +164,7 @@ class MysqlPtOscAdapterTest < Test::Unit::TestCase
 
         should 'add a DROP COLUMN command to the commands hash' do
           table_name = Faker::Lorem.word
-          index_name = Faker::Lorem.word
+          index_name = Faker::Lorem.words.join('_')
           @adapter.remove_index!(table_name, index_name)
           assert_equal "DROP INDEX `#{index_name}`", @adapter.send(:get_commands, table_name).first
         end


### PR DESCRIPTION
If an `ALTER` command is being called on the `MysqlPtOscAdapter` without coming from a `PtOscMigration`, this usually means that commands will be queued up in the commands hash and never actually executed. This results in silent failure.

To make this failure more apparent, issue a warning when `add_command` is called and `PtOscMigration` does not appear in the stack trace.