### PR TITLE
Locks mysql2 gem to ~> 0.3.10, since newer 0.4 causes problems.

### DIFF
--- a/pt-osc.gemspec
+++ b/pt-osc.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'activerecord-import', '>= 0.5.0'
 
   spec.add_runtime_dependency 'activerecord', '~> 3.2'
-  spec.add_runtime_dependency 'mysql2'
+  spec.add_runtime_dependency 'mysql2', '~> 0.3.10'
 end


### PR DESCRIPTION
Setting up for the first time:
```
Taavi:pt-osc taavi$ bundle install
Fetching gem metadata from https://rubygems.org/...........
Fetching additional metadata from https://rubygems.org/..
Resolving dependencies...
Installing rake 11.1.2
…
Installing mysql2 0.4.3
…
Your bundle is complete!
Use `bundle show [gemname]` to see where a bundled gem is installed.
```
And then:
```
Taavi:pt-osc taavi$ bundle exec rake
/Users/taavi/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/bundler-1.7.8/lib/bundler/source/rubygems.rb:191: warning: shadowing outer local variable - spec
/Users/taavi/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/activesupport-3.2.22.2/lib/active_support/core_ext/load_error.rb:9: warning: method redefined; discarding old path
/Users/taavi/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/bundler-1.7.8/lib/bundler/rubygems_integration.rb:266:in `block in replace_gem': can't activate mysql2 (~> 0.3.10), already activated mysql2-0.4.3. Make sure all dependencies are added to Gemfile. (Gem::LoadError)
	from /Users/taavi/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/activerecord-3.2.22.2/lib/active_record/connection_adapters/mysql2_adapter.rb:3:in `<top (required)>'
…
rake aborted!
```

This PR seems to fix this particular issue. :)