### PR TITLE
Throws an exception when a migration tries to use the raw SQL `execute`.

### DIFF
--- a/lib/active_record/pt_osc_migration.rb
+++ b/lib/active_record/pt_osc_migration.rb
@@ -3,6 +3,8 @@ require 'active_record/connection_adapters/mysql_pt_osc_adapter'
 require 'shellwords'
 
 module ActiveRecord
+  class UnsupportedMigrationError < ActiveRecordError; end
+
   class PtOscMigration < Migration
     # @TODO whitelist all valid pt-osc flags
     PERCONA_FLAGS = {
@@ -262,6 +264,10 @@ module ActiveRecord
       else
         flag
       end
+    end
+
+    def execute(sql)
+      raise ActiveRecord::UnsupportedMigrationError.new("Raw `execute` isn't supported by the pt-osc gem.")
     end
   end
 end

--- a/test/functional/pt_osc_migration_functional_test.rb
+++ b/test/functional/pt_osc_migration_functional_test.rb
@@ -38,6 +38,22 @@ class PtOscMigrationFunctionalTest < ActiveRecord::TestCase
           ActiveRecord::Base.connection.execute "DROP TABLE IF EXISTS `#{@table_name}`;"
         end
 
+        context 'a raw SQL execute migration' do
+          setup do
+            TestMigration.class_eval <<-EVAL
+            def up
+              execute 'SELECT 1'
+            end
+            EVAL
+          end
+
+          should 'throw an exception' do
+            assert_raise ActiveRecord::UnsupportedMigrationError do
+              @migration.migrate(:up)
+            end
+          end
+        end
+
         context 'a migration with only ALTER statements' do
           setup do
             @renamed_column_name = 'foobar'

--- a/test/functional/pt_osc_migration_functional_test.rb
+++ b/test/functional/pt_osc_migration_functional_test.rb
@@ -45,6 +45,15 @@ class PtOscMigrationFunctionalTest < ActiveRecord::TestCase
               execute 'SELECT 1'
             end
             EVAL
+            @migration.expects(:print_pt_osc).never
+            @migration.expects(:execute_pt_osc).never
+            @migration.connection.expects(:execute).never
+          end
+
+          teardown do
+            @migration.unstub(:print_pt_osc)
+            @migration.unstub(:execute_pt_osc)
+            @migration.connection.unstub(:execute)
           end
 
           should 'throw an exception' do


### PR DESCRIPTION
Otherwise you can accidentally issue a direct `ALTER` to your database, and lock it up…avoidance of which is the whole point of using `pt-online-schema-change`. :)