### PR TITLE
Lock to newer versions of Bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ cache:
   - bundler
   - apt
 bundler_args: --binstubs --retry=5
+before_install:
+  - gem install bundler -v 1.12.4
 before_script:
   - $TRAVIS_BUILD_DIR/test/travisci/install_pt_osc.sh
   - unset RAILS_ENV

--- a/pt-osc.gemspec
+++ b/pt-osc.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '>= 1.6'
+  spec.add_development_dependency 'bundler', '>= 1.10'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'shoulda'
   spec.add_development_dependency 'faker'


### PR DESCRIPTION
This fixes the issue where bundling would fail in Travis.